### PR TITLE
Update Lab_4_4_Model_driven_app.md

### DIFF
--- a/Instructions/Labs/Lab_4_4_Model_driven_app.md
+++ b/Instructions/Labs/Lab_4_4_Model_driven_app.md
@@ -27,13 +27,13 @@ Both will be integrated to the model-driven app for a better user-experience.
 For simplicity and time’s sake, we will not be addressing all of the Expense Report columns in this lab.
 
 ### Task #1: Create app
-1. If you are not already, sign in to https://make.powerapps.com.
+1. If you are not already, sign in to `https://make.powerapps.com`.
 2. Select the environment that you imported the Expense Report solution into at the top right if it is not already selected.
 3. Using the navigation on the left, select **Solutions.**
 4. Open the Expense Report solution.
 5. On the command bar, select the **+ New** button.
 6. From the menu that appears, go to **App > Model-driven app.**
-7. Enter *Employee Expense Management* for Name and select **Create.**
+7. Enter *`Employee Expense Management`* for Name and select **Create.**
 8. After your new model-driven application loads, select the **+ Add Page** button.
 9. On the **Add Page** screen, choose **Dataverse table.** 
 10. Select the following tables:
@@ -43,7 +43,7 @@ For simplicity and time’s sake, we will not be addressing all of the Expense R
 12. After you have selected both tables, select **Add.**
 13. Using the navigation icons on the left side of the screen, select **Navigation.**
 14. On the Navigation Pane, select **New Group** below where it says Navigation. You may need to expand the menu on the left.
-15. On the right side of the screen, in the Display options section, change the Title property to *Expense Reports.*
+15. On the right side of the screen, in the Display options section, change the Title property to *`Expense Reports`*.
 16. Under the Navigation section, select the **Ellipsis (three dots)** next to **Expense Reports.** From the menu that appears, select **Move Up**. Expense Reports should now appear above Expense Lines in the navigation.
 17. Under Navigation, select the **Expense Reports** form.
 18. Go to the In this app section on the right side of the screen.
@@ -70,9 +70,9 @@ For simplicity and time’s sake, we will not be addressing all of the Expense R
 1. Select **Expense Reports** from the left-hand navigation (also known as the sitemap).
 2. Select **+ New.**
 3. Enter the fields as follows:
-    - Report Name: *New Test Report*
-    - Report Purpose: Select **Conference**
-    - Report due date: Select **Today's date**
+    - Report Name: **`New Test Report`**
+    - Report Purpose: Select **`Conference`**
+    - Report due date: Select **`Today's date`**
 4. Select **Save & Close.** This will create the new Test Report and you should be able to see it on the Active Expense Reports view.
 5. Change view to **Expense Reports Due Today** by using the drop-down next to Active Expense Reports.
 6. You may add some more test records.


### PR DESCRIPTION
Recommend using backticks for any text that must/will be typed by user (should be an ALH-agnostic method for 'typetext')  Also, best to put periods outside of any backticked/TTed strings so the period is not typed in by Student.  Also, Students/Instructors will sometimes indicate anything that is *not* intended to be 'typetexted' shouldn't use backticks for emphasis, but rather either bold or italics.  (** or *)

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-