### PR TITLE
Backfill missing lab metadata (7 files)

### DIFF
--- a/Instructions/Labs/Lab_0_1_Environment.md
+++ b/Instructions/Labs/Lab_0_1_Environment.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
+  title: 'Lab 0: Validate lab environment'
+  description: If you are being provided with a tenant as a part of an instructor-led
+    training delivery, please note that the tenant is made available for the purpose
+    of supporting the hands-on labs in the instructor-led training.
+  duration: 38 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 0 - Validate lab environment

--- a/Instructions/Labs/Lab_1_1_Tables_and_Columns.md
+++ b/Instructions/Labs/Lab_1_1_Tables_and_Columns.md
@@ -1,6 +1,18 @@
 ---
 lab:
-    title: 'Lab 1.1: Create and manage tables and columns'
+  title: 'Lab 1.1: Create and manage tables and columns'
+  description: Bellows College is an educational organization with multiple campuses
+    and programs. Many of Bellow Colleges instructors and administrators need to attend
+    events, and purchase items. Historically tracking these expenses has been a challenge.
+    Campus administration would like to modernize their expense reporting system by
+    providing employees with a digital way to report expenses. Ideally, they want
+    their users to complete an Expense Report after each event or purchase. For each
+    Expense Report, they want them to be able to add individual expense line items.
+    They have already started working on this solution. The Expense Report table has
+    been created. You have been asked to take over the project and complete it.
+  duration: 160 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 1.1: Create and manage tables and columns

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -1,6 +1,18 @@
 ---
 lab:
-    title: 'Lab 2.1: Create calculated and rollup fields'
+  title: 'Lab 2.1: Create calculated and rollup fields'
+  description: Bellows College is an educational organization with multiple campuses
+    and programs. Many of Bellow Colleges instructors and administrators need to attend
+    events, and purchase items. Historically tracking these expenses has been a challenge.
+    Campus administration would like to modernize their expense reporting system by
+    providing employees with a digital way to report expenses. Ideally, they want
+    their users to complete an Expense Report after each event or purchase. For each
+    Expense Report, they want them to be able to add individual expense line items.
+    They have already started working on this solution. The Expense Report table has
+    been created. You have been asked to take over the project and complete it.
+  duration: 88 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 2.1: Create calculated and rollup fields 

--- a/Instructions/Labs/Lab_4_1_Views.md
+++ b/Instructions/Labs/Lab_4_1_Views.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 4.1: Visualize data with views'
+  title: 'Lab 4.1: Visualize data with views'
+  description: Bellows College is an educational organization with multiple campuses
+    and programs. Many of Bellow Colleges instructors and administrators need to attend
+    events, and purchase items. Historically tracking these expenses has been a challenge.
+  duration: 152 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.1: Visualize data with views

--- a/Instructions/Labs/Lab_4_2_Create_a_form.md
+++ b/Instructions/Labs/Lab_4_2_Create_a_form.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Lab 4.2: Create forms'
+  title: 'Lab 4.2: Create forms'
+  description: Bellows College is an educational organization with multiple campuses
+    and programs. Many of Bellow Colleges instructors and administrators need to attend
+    events, and purchase items. Historically tracking these expenses has been a challenge.
+    Campus administration would like to modernize their expense reporting system by
+    providing employees with a digital way to report expenses. Throughout this course,
+    you will build applications and perform automation to enable the Bellows College
+    employees to manage expenses.
+  duration: 86 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.2: Create forms

--- a/Instructions/Labs/Lab_4_3_Dashboard.md
+++ b/Instructions/Labs/Lab_4_3_Dashboard.md
@@ -1,6 +1,16 @@
 ---
 lab:
-    title: 'Lab 4.3: Create a dashboard'
+  title: 'Lab 4.3: Create a dashboard'
+  description: Bellows College is an educational organization with multiple campuses
+    and programs. Many of Bellow Colleges instructors and administrators need to attend
+    events, and purchase items. Historically tracking these expenses has been a challenge.
+    Campus administration would like to modernize their expense reporting system by
+    providing employees with a digital way to report expenses. Throughout this course,
+    you will build applications and perform automation to enable the Bellows College
+    employees to manage expenses.
+  duration: 146 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.3: Create a dashboard 

--- a/Instructions/Labs/Lab_4_4_Model_driven_app.md
+++ b/Instructions/Labs/Lab_4_4_Model_driven_app.md
@@ -1,6 +1,11 @@
 ---
 lab:
-    title: 'Lab 4.4: Build a model-driven app'
+  title: 'Lab 4.4: Build a model-driven app'
+  description: Bellows College is an educational organization with multiple campuses
+    and programs.
+  duration: 92 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.4: Build a model-driven app


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 7

- `Instructions/Labs/Lab_0_1_Environment.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_1_1_Tables_and_Columns.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_1_Views.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_2_Create_a_form.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_3_Dashboard.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_4_Model_driven_app.md` (description,duration,level,islab)
