### PR TITLE
Backfill missing lab metadata (7 files)

### DIFF
--- a/Instructions/Labs/Lab_0_1_Environment.md
+++ b/Instructions/Labs/Lab_0_1_Environment.md
@@ -1,6 +1,12 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
+  title: 'Lab 0: Validate lab environment'
+  description: In this exercise, you will verify that you can access Power Apps.
+  duration: 38 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Power Apps
 ---
 
 # Practice Lab 0 - Validate lab environment

--- a/Instructions/Labs/Lab_0_1_Environment.md
+++ b/Instructions/Labs/Lab_0_1_Environment.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 0: Validate lab environment'
   description: In this exercise, you will verify that you can access Power Apps.
-  duration: 38 minutes
+  duration: 10 minutes
   level: 100
   islab: true
   primarytopics:

--- a/Instructions/Labs/Lab_1_1_Tables_and_Columns.md
+++ b/Instructions/Labs/Lab_1_1_Tables_and_Columns.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 1.1: Create and manage tables and columns'
+  title: 'Lab 1.1: Create and manage tables and columns'
+  description: 'Upon Successful completion of this lab, you will:'
+  duration: 160 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 1.1: Create and manage tables and columns

--- a/Instructions/Labs/Lab_1_1_Tables_and_Columns.md
+++ b/Instructions/Labs/Lab_1_1_Tables_and_Columns.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 1.1: Create and manage tables and columns'
   description: 'Upon Successful completion of this lab, you will:'
-  duration: 160 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 2.1: Create calculated and rollup fields'
   description: 'Upon Successful completion of this lab, you will:'
-  duration: 88 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 2.1: Create calculated and rollup fields'
+  title: 'Lab 2.1: Create calculated and rollup fields'
+  description: 'Upon Successful completion of this lab, you will:'
+  duration: 88 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 2.1: Create calculated and rollup fields 

--- a/Instructions/Labs/Lab_4_1_Views.md
+++ b/Instructions/Labs/Lab_4_1_Views.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 4.1: Visualize data with views'
+  title: 'Lab 4.1: Visualize data with views'
+  description: 'As part of creating the model-driven app, you will complete the following:'
+  duration: 152 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.1: Visualize data with views

--- a/Instructions/Labs/Lab_4_1_Views.md
+++ b/Instructions/Labs/Lab_4_1_Views.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 4.1: Visualize data with views'
   description: 'As part of creating the model-driven app, you will complete the following:'
-  duration: 152 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Lab_4_2_Create_a_form.md
+++ b/Instructions/Labs/Lab_4_2_Create_a_form.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 4.2: Create forms'
+  title: 'Lab 4.2: Create forms'
+  description: 'Upon Successful Completion of this lab, you will have completed the following:'
+  duration: 86 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.2: Create forms

--- a/Instructions/Labs/Lab_4_2_Create_a_form.md
+++ b/Instructions/Labs/Lab_4_2_Create_a_form.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 4.2: Create forms'
   description: 'Upon Successful Completion of this lab, you will have completed the following:'
-  duration: 86 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Lab_4_3_Dashboard.md
+++ b/Instructions/Labs/Lab_4_3_Dashboard.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 4.3: Create a dashboard'
+  title: 'Lab 4.3: Create a dashboard'
+  description: 'Upon Successful completion of this lab, you will:'
+  duration: 146 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.3: Create a dashboard 

--- a/Instructions/Labs/Lab_4_3_Dashboard.md
+++ b/Instructions/Labs/Lab_4_3_Dashboard.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 4.3: Create a dashboard'
   description: 'Upon Successful completion of this lab, you will:'
-  duration: 146 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Lab_4_4_Model_driven_app.md
+++ b/Instructions/Labs/Lab_4_4_Model_driven_app.md
@@ -2,7 +2,7 @@
 lab:
   title: 'Lab 4.4: Build a model-driven app'
   description: 'As part of configuring the model-driven app, you will complete the following:'
-  duration: 92 minutes
+  duration: 20 minutes
   level: 100
   islab: true
 ---

--- a/Instructions/Labs/Lab_4_4_Model_driven_app.md
+++ b/Instructions/Labs/Lab_4_4_Model_driven_app.md
@@ -1,6 +1,10 @@
 ---
 lab:
-    title: 'Lab 4.4: Build a model-driven app'
+  title: 'Lab 4.4: Build a model-driven app'
+  description: 'As part of configuring the model-driven app, you will complete the following:'
+  duration: 92 minutes
+  level: 100
+  islab: true
 ---
 
 # Lab 4.4: Build a model-driven app


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 7

- `Instructions/Labs/Lab_0_1_Environment.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/Lab_1_1_Tables_and_Columns.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_1_Views.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_2_Create_a_form.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_3_Dashboard.md` (description,duration,level,islab)
- `Instructions/Labs/Lab_4_4_Model_driven_app.md` (description,duration,level,islab)
