### PR TITLE
Lab 2.1: Align navigation and save steps with Power Apps Maker portal UI ``

### DIFF
--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -28,7 +28,7 @@ Upon Successful completion of this lab, you will:
 **Objective:** In this exercise, create a rollup and a calculated field on the expense report table.
 
 ### Task #1: Add a rollup field to the Expense Report table
-1. Navigate to the Power Apps Maker portal `https://make.powerapps.com`
+1. Navigate to the Power Apps Maker portal https://make.powerapps.com
 2. Make sure that you are working in the environment that you imported the Expense Report solution into during the last exercise.
 3. Using the navigation on the left, select **Solutions.**
 4. Locate and select the Expense Report solution.
@@ -50,7 +50,7 @@ Upon Successful completion of this lab, you will:
 20. Select the green check mark and then select the **Save and Close** button.
 
 ### Task #2: Add a Power FX Formula Calculated field to the Expense Report table
-1. Navigate to the Power Apps Maker portal `https://make.powerapps.com`
+1. Navigate to the Power Apps Maker portal https://make.powerapps.com
 2. Make sure that you are working in the environment that you imported the Expense Report solution into during the last exercise.
 3. Using the navigation on the left, select **Solutions.**
 4. Locate and select the Expense Report solution.

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -61,4 +61,4 @@ Upon Successful completion of this lab, you will:
 9. Select **Formula** for Data type.
 10. Enter the following formula: `DateAdd('Report Due Date',2)`
 11. Set the Format field to **Date Only.**
-12. Select the **Save** button. (You need to save the column before you can configure it.)
+12. Select the **Save** button.

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -28,7 +28,7 @@ Upon Successful completion of this lab, you will:
 **Objective:** In this exercise, create a rollup and a calculated field on the expense report table.
 
 ### Task #1: Add a rollup field to the Expense Report table
-1. If necessary, navigate to the Power Apps Maker Portal.
+1. Navigate to the Power Apps Maker portal `https://make.powerapps.com`
 2. Make sure that you are working in the environment that you imported the Expense Report solution into during the last exercise.
 3. Using the navigation on the left, select **Solutions.**
 4. Locate and select the Expense Report solution.

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -39,7 +39,7 @@ Upon Successful completion of this lab, you will:
 9. Select **Currency** for Data type.
 10. In Required, select **Optional.**
 11. In the Behavior field, select **Rollup.**
-12. Select the **Save** button. (You need to save the column before you can configure it.)
+12. Select the **Save** and **Edit** button. (You need to save the column before you can configure it.)
 13. Once the Column is saved, a pop-up window should appear. (If you get a pop-up message, you may need to allow pop ups.)
 14. Under RELATED ENTITY, select **+Add related entity.**
 15. Select **(Expense Lines) Expense Report.**
@@ -50,7 +50,7 @@ Upon Successful completion of this lab, you will:
 20. Select the green check mark and then select the **Save and Close** button.
 
 ### Task #2: Add a Power FX Formula Calculated field to the Expense Report table
-1. If necessary, navigate to the Power Apps Maker Portal.
+1. Navigate to the Power Apps Maker portal `https://make.powerapps.com`
 2. Make sure that you are working in the environment that you imported the Expense Report solution into during the last exercise.
 3. Using the navigation on the left, select **Solutions.**
 4. Locate and select the Expense Report solution.

--- a/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
+++ b/Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md
@@ -39,7 +39,7 @@ Upon Successful completion of this lab, you will:
 9. Select **Currency** for Data type.
 10. In Required, select **Optional.**
 11. In the Behavior field, select **Rollup.**
-12. Select the **Save** and **Edit** button. (You need to save the column before you can configure it.)
+12. Select the **Save** and **Edit** button.
 13. Once the Column is saved, a pop-up window should appear. (If you get a pop-up message, you may need to allow pop ups.)
 14. Under RELATED ENTITY, select **+Add related entity.**
 15. Select **(Expense Lines) Expense Report.**


### PR DESCRIPTION
## Description

This PR updates Lab 2.1 instructions to better align with the current Power Apps Maker portal experience by removing conditional wording, adding the explicit Maker portal URL, and updating the save action to match the modern UI.

## Changes

- Updated navigation steps to directly reference the Power Apps Maker portal, including the official URL
- Removed conditional wording (“If necessary”) from navigation instructions
- Updated the save instruction to use **Save and Edit**, matching the current Power Apps Maker portal UI
- Removed outdated explanatory text from the save step, as the calculated column is fully configured before saving and no further configuration follows.

## Files updated
`Instructions/Labs/Lab_2_1_Calculated_and_Rollup.md`